### PR TITLE
chore: upgrade bullmq to v5

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 package-lock=false
-@zakodium:registry=https://registry.npmjs.org/
+@zakodium:registry=https://npm.pkg.github.com

--- a/adonis-typings/index.ts
+++ b/adonis-typings/index.ts
@@ -8,11 +8,11 @@
 declare module '@ioc:Rlanz/Queue' {
 	import type {
 		ConnectionOptions,
-		WorkerOptions,
-		QueueOptions,
-		Queue as BullQueue,
-		JobsOptions,
 		Job,
+		JobsOptions,
+		Queue as BullQueue,
+		QueueOptions,
+		WorkerOptions,
 	} from 'bullmq';
 
 	export type DataForJob<K extends string> = K extends keyof JobsList
@@ -25,8 +25,8 @@ declare module '@ioc:Rlanz/Queue' {
 
 	export type QueueConfig = {
 		connection: ConnectionOptions;
-		queue: QueueOptions;
-		worker: WorkerOptions;
+		queue: Omit<QueueOptions, 'connection'>;
+		worker: Omit<WorkerOptions, 'connection'>;
 		jobs: JobsOptions;
 	};
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "bullmq": "^4.12.3"
+    "bullmq": "^5.7.6"
   },
   "devDependencies": {
     "@adonisjs/application": "^5.3.0",
@@ -37,7 +37,7 @@
     "@adonisjs/sink": "^5.4.3",
     "copyfiles": "^2.4.1",
     "del-cli": "^5.1.0",
-    "eslint": "^8.51.0",
+    "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-adonis": "^2.1.1",
     "eslint-plugin-prettier": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zakodium/bull-queue",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Queue system based on BullMQ for AdonisJS",
   "homepage": "https://github.com/romainlanz/adonis-bull-queue#readme",
   "license": "MIT",

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -5,8 +5,8 @@
  * @copyright Romain Lanz <romain.lanz@pm.me>
  */
 
-import { Queue, Worker } from 'bullmq';
 import type { JobsOptions } from 'bullmq';
+import { Queue, Worker } from 'bullmq';
 import type { LoggerContract } from '@ioc:Adonis/Core/Logger';
 import type { ApplicationContract } from '@ioc:Adonis/Core/Application';
 import type { DataForJob, JobsList, QueueConfig } from '@ioc:Rlanz/Queue';
@@ -118,5 +118,3 @@ export class BullManager {
 		return this.queues.get(queueName);
 	}
 }
-
-

--- a/src/Queue.ts
+++ b/src/Queue.ts
@@ -64,7 +64,7 @@ export class BullManager {
 				try {
 					jobHandler = this.app.container.make(job.name, [job]);
 				} catch (e) {
-					this.logger.error(`Job handler for ${job.name} not found`);
+					this.logger.error(e, `Job handler for ${job.name} failed to load`);
 					return;
 				}
 


### PR DESCRIPTION
- Change npm repository to be github
- Made minor bump even if bullmq upgrade is major bump (no one except us relies on this package)